### PR TITLE
Adjust composer configuration for TYPO3 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,15 @@
   "type": "typo3-cms-extension",
   "keywords": ["TYPO3 CMS", "Guestbook, Guest book"],
   "homepage": "https://github.com/jainishsenjaliya/js_guestbook",
-  "version": "1.0.16",
   "support": {
     "issues": "https://github.com/jainishsenjaliya/js_guestbook/issues"
   },
   "require": {
-      "typo3/cms": "6.0.0 - 8.9.99"
+      "typo3/cms": "6.0.0 - 8.7.99"
+  },
+  "autoload": {
+    "psr-4": {
+      "JS\\JsGuestbook\\": "Classes/"
+    }
   }
 }

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -25,7 +25,7 @@ $EM_CONF[$_EXTKEY] = array(
 	'version' => '2.0.1',
 	'constraints' => array(
 		'depends' => array(
-			'typo3' => '6.0.0 - 7.6.99',
+			'typo3' => '6.0.0 - 8.7.99',
 			'js_paginate' => '1.0.3 - 3.9.99',
 		),
 		'conflicts' => array(


### PR DESCRIPTION
With this adjustments, js_guestbook can be installed on TYPO3 8 LTS with composer.

Changes:

- Autoloading information added
- Fixed version number removed (use tags instead)